### PR TITLE
Support for Adapt.adapt

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,12 +4,14 @@ uuid = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
 version = "1.2.2"
 
 [deps]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 SplitApplyCombine = "03a91e81-4c3e-53e1-a0a4-9c0c8f19dd66"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
 julia = "1"
+Adapt = "1, 2, 3"
 SplitApplyCombine = "1"
 Tables = "1"
 

--- a/src/FlexTable.jl
+++ b/src/FlexTable.jl
@@ -310,3 +310,6 @@ Base.isless(t1::AbstractVector, t2::FlexTable{1}) = isless(t1, rows(t2))
 Base.isless(t1::FlexTable{1}, t2::FlexTable{1}) = isless(rows(t1), rows(t2))
 
 Base.hash(t::FlexTable, h::UInt) = hash(rows(t), h)
+
+
+Adapt.adapt_structure(to, t::FlexTable{N}) where N = FlexTable{N}(; Adapt.adapt(to, getfield(t, :data))...)

--- a/src/Table.jl
+++ b/src/Table.jl
@@ -319,3 +319,6 @@ end
 function Base.vec(t::Table{<:NamedTuple{names}}) where {names}
     return Table(map(vec, columns(t)))
 end
+
+
+Adapt.adapt_structure(to, t::Table) = Table(; Adapt.adapt(to, getfield(t, :data))...)

--- a/src/TypedTables.jl
+++ b/src/TypedTables.jl
@@ -3,6 +3,7 @@ module TypedTables
 using Unicode
 using Tables
 using SplitApplyCombine
+import Adapt
 
 using Base: @propagate_inbounds, @pure, OneTo, Fix2
 import Tables.columns, Tables.rows

--- a/test/FlexTable.jl
+++ b/test/FlexTable.jl
@@ -224,4 +224,12 @@
                              customer_id = [2, 2, 3, 3],
                              items = ["Socks", "Tie", "Shirt", "Underwear"])
     end
+
+    @testset "adapt" begin
+        tbl = FlexTable(a = randn(Float32, 10^2), b = rand(Float64, 10^2), c = rand(1:100, 10^2))
+        @test typeof(@inferred adapt(TestArrayConverter(), tbl)) == typeof(tbl)
+        adapted_tbl = adapt(TestArrayConverter(), tbl)
+        @test propertynames(adapted_tbl) == propertynames(tbl)
+        @test adapted_tbl == tbl
+    end
 end

--- a/test/Table.jl
+++ b/test/Table.jl
@@ -221,4 +221,12 @@
                           customer_id = [2, 2, 3, 3],
                           items = ["Socks", "Tie", "Shirt", missing]))
     end
+
+    @testset "adapt" begin
+        tbl = Table(a = randn(Float32, 10^2), b = rand(Float64, 10^2), c = rand(1:100, 10^2))
+        @test typeof(@inferred adapt(TestArrayConverter(), tbl)) == typeof(tbl)
+        adapted_tbl = adapt(TestArrayConverter(), tbl)
+        @test propertynames(adapted_tbl) == propertynames(tbl)
+        @test adapted_tbl == tbl
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,12 @@
 using Test
 using TypedTables
 using SplitApplyCombine
+using Adapt
 using Tables
+
+# Here because Julia v1.0 doesn't allow type definitions inside of testsets:
+struct TestArrayConverter end
+Adapt.adapt_storage(::TestArrayConverter, xs::AbstractArray) = convert(Array, xs)
 
 include("properties.jl")
 include("Table.jl")


### PR DESCRIPTION
With this, we can do

```julia
using TypedTables, Adapt, CUDA

tbl = Table(a = randn(Float32, 10^5), b = rand(Float32, 10^5))
v = rand(Float32, 10^5)

cutbl = adapt(CuArray, tbl)
cuv = adapt(CuArray, v)

cutbl.a .* cutbl.b isa CuArray

broadcast((x, row) -> x + row.a * row.b, cuv, cutbl) isa CuArray
```

There's one limitation, currently: When broadcasting over rows, broadcast doesn't know the resulting array should be a CuArray if there isn't another `CuArray` in the argument list (like `cuv` above):

```julia
broadcast(row -> row.a * row.b, cutbl) isa Array
```

This will need custom broadcasting I guess, but I'm not quite sure how to go about it. StructArrays has the same limitation at the moment (CC @piever). But maybe we can merge this and improve on it later on?