### PR TITLE
convenience functions to select or drop columns

### DIFF
--- a/src/Table.jl
+++ b/src/Table.jl
@@ -327,3 +327,27 @@ end
 
 
 Adapt.adapt_structure(to, t::Table) = Table(; Adapt.adapt(to, getfield(t, :data))...)
+
+"""
+    select(table::Table, selectedcolumns...)::Table
+
+Returns a new `Table` with only the selected columns in that order. Throws an error if `getproperty` can't find the requested column(s) in `table`.
+"""
+function select(table::Table, selectedcolumns...)::Table
+    
+    if length(selectedcolumns) < 1
+        error("Specify at least 1 column.")
+    end
+
+    Table(NamedTuple{ selectedcolumns }( getproperty.( Ref(table), selectedcolumns ) ))
+end
+
+"""
+    dropcolumns(table::Table, dropcolumns...)::Table
+
+Returns a new `Table` or `FlexTable`, based on `table` without the columns to be dropped.
+"""
+function dropcolumns(table::Table, dropcolumns...)::Table
+    keepcolumns = filter(c -> !(c in dropcolumns), propertynames(table))
+    select(table, keepcolumns...)
+end

--- a/src/TypedTables.jl
+++ b/src/TypedTables.jl
@@ -9,7 +9,7 @@ using Base: @propagate_inbounds, @pure, OneTo, Fix2
 import Tables.columns, Tables.rows
 
 export @Compute, @Select
-export Table, FlexTable, columns, rows, columnnames, showtable
+export Table, FlexTable, columns, rows, columnnames, showtable, select, dropcolumns
 
 # Resultant element type of given column arrays
 @generated function _eltypes(a::NamedTuple{names, T}) where {names, T <: Tuple{Vararg{AbstractArray}}}

--- a/test/Table.jl
+++ b/test/Table.jl
@@ -1,4 +1,19 @@
 @testset "Table" begin
+
+    @testset "Selecting and dropping" begin
+        table = Table(a = [1,2,3], b = ["1","2","3"], c = [1.0, 2.0, 3.0])
+        @test table isa Table
+        @test select(table, :b) == Table(b = table.b)
+        @test select(table, :c, :b, :a) == Table(c = table.c, b = table.b, a = table.a)
+
+        @test dropcolumns(table, :b) == Table(a = table.a, c = table.c)
+        @test dropcolumns(table) == table
+
+        @test_throws Exception select(table)
+        @test_throws Exception select(table, :not_there)
+        @test_throws Exception select(table, :a, :a)    
+    end
+
     t = @inferred(Table(a = [1, 2, 3], b = [2.0, 4.0, 6.0]))::Table
 
     @test Table(t) == t


### PR DESCRIPTION
We find these very handy. They can be in our "Utils" package, or just in the latest TypedTables?

Did I miss better / existing ways to do something like `basics = select(pointcloud, :position, :intensity)` ?