### PR TITLE
Add some convenience functions for handling properties

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 authors = ["Andy Ferris <ferris.andy@gmail.com>"]
 name = "TypedTables"
 uuid = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
-version = "1.2.4"
+version = "1.3.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/docs/src/man/reference.md
+++ b/docs/src/man/reference.md
@@ -20,6 +20,14 @@ TypedTables.columns
 TypedTables.columnnames
 ```
 
+## Property selection
+
+```@docs
+TypedTables.getproperties
+TypedTables.deleteproperty
+TypedTables.deleteproperties
+```
+
 ## Convenience macros
 
 These macros return *functions* that can be applied to tables and rows.

--- a/src/TypedTables.jl
+++ b/src/TypedTables.jl
@@ -8,7 +8,7 @@ import Adapt
 using Base: @propagate_inbounds, @pure, OneTo, Fix2
 import Tables.columns, Tables.rows
 
-export @Compute, @Select
+export @Compute, @Select, getproperties, deleteproperty, deleteproperties
 export Table, FlexTable, columns, rows, columnnames, showtable
 
 # Resultant element type of given column arrays
@@ -20,7 +20,7 @@ export Table, FlexTable, columns, rows, columnnames, showtable
     return NamedTuple{names, Tuple{Ts...}}
 end
 
-_ndims(a::NamedTuple{<:Any, T}) where {T} = _ndims(T)
+_ndims(::NamedTuple{<:Any, T}) where {T} = _ndims(T)
 _ndims(::Type{<:Tuple{Vararg{AbstractArray{<:Any, n}}}}) where {n} = n
 
 # The following code causes newer versions of Julia to hang in precompilation
@@ -39,6 +39,10 @@ if VERSION < v"1.2.0-DEV.291"
         end
     end
 end
+
+# Apparently by default this is slower than necessary because we go through generic introspection.
+# TODO - we should probably make a PR for Base.
+Base.propertynames(::NamedTuple{names}) where {names} = names
 
 include("properties.jl")
 include("Table.jl")

--- a/test/FlexTable.jl
+++ b/test/FlexTable.jl
@@ -52,7 +52,7 @@
          2 │ 2  4.0
          3 │ 3  6.0"""
 
-    @test @inferred(TypedTables.getproperties(:b, :a)(t))::FlexTable == FlexTable(b = [2.0, 4.0, 6.0], a = [1, 2, 3])
+    @test @inferred((x -> getproperties(x, (:b, :a)))(t))::FlexTable == FlexTable(b = [2.0, 4.0, 6.0], a = [1, 2, 3])
 
     @test t == t
     @test t == rows(t)
@@ -154,10 +154,10 @@
         @test filter(getproperty(:c), t)::FlexTable == FlexTable(a = [1,3], b = [2.0, 6.0], c = [true, true])
         @test findall(getproperty(:c), t)::Vector{Int} == [1, 3]
 
-        @test map(TypedTables.getproperties(:a), t)::FlexTable == FlexTable(a = [1,2,3])
-        @test mapview(TypedTables.getproperties(:a), t)::FlexTable == FlexTable(a = [1,2,3])
-        @test broadcast(TypedTables.getproperties(:a), t) == FlexTable(a = [1,2,3])
-        @test mapreduce(TypedTables.getproperties(:a), (acc, row) -> acc + row.a, t; init = 0) === 6
+        @test map(getproperties((:a,)), t)::FlexTable == FlexTable(a = [1,2,3])
+        @test mapview(getproperties((:a,)), t)::FlexTable == FlexTable(a = [1,2,3])
+        @test broadcast(getproperties((:a,)), t) == FlexTable(a = [1,2,3])
+        @test mapreduce(getproperties((:a,)), (acc, row) -> acc + row.a, t; init = 0) === 6
     end
 
     @testset "@Select and @Compute on FlexTables" begin

--- a/test/Table.jl
+++ b/test/Table.jl
@@ -53,7 +53,7 @@
          2 │ 2  4.0
          3 │ 3  6.0"""
 
-    @test @inferred(TypedTables.getproperties(:b, :a)(t))::Table == Table(b = [2.0, 4.0, 6.0], a = [1, 2, 3])
+    @test @inferred(getproperties((:b, :a))(t))::Table == Table(b = [2.0, 4.0, 6.0], a = [1, 2, 3])
 
     @test t == t
     @test isequal(t, t)
@@ -141,10 +141,10 @@
         @test @inferred(filter(getproperty(:c), t))::Table == Table(a = [1,3], b = [2.0, 6.0], c = [true, true])
         @test @inferred(findall(getproperty(:c), t))::Vector{Int} == [1, 3]
 
-        @test @inferred(map(TypedTables.getproperties(:a), t))::Table == Table(a = [1,2,3])
-        @test @inferred(mapview(TypedTables.getproperties(:a), t))::Table == Table(a = [1,2,3])
-        @test @inferred(broadcast(TypedTables.getproperties(:a), t))::Table == Table(a = [1,2,3])
-        @test @inferred(mapreduce(TypedTables.getproperties(:a), (acc, row) -> acc + row.a, t; init = 0)) === 6
+        @test @inferred(map(getproperties((:a,)), t))::Table == Table(a = [1,2,3])
+        @test @inferred(mapview(getproperties((:a,)), t))::Table == Table(a = [1,2,3])
+        @test @inferred(broadcast(getproperties((:a,)), t))::Table == Table(a = [1,2,3])
+        @test @inferred(mapreduce(getproperties((:a,)), (acc, row) -> acc + row.a, t; init = 0)) === 6
     end
 
     @testset "@Select and @Compute on Tables" begin

--- a/test/properties.jl
+++ b/test/properties.jl
@@ -1,8 +1,19 @@
 @testset "Property interface" begin
-    nt = (a=1,b=2.0,c=false)
-    @test @inferred(getproperty(:b)(nt)) === 2.0
+    nt = (a=1, b=2.0, c=false, d=:abc)
 
-    @test @inferred(TypedTables.getproperties(:b)(nt)) === (b = 2.0,)
+    @test @inferred((x -> getproperty(:b)(x))(nt)) === 2.0
+
+    @test @inferred((x -> getproperties(x, (:a, :c)))(nt)) === (a = 1, c = false)
+    @test @inferred((x -> getproperties((:a, :c))(x))(nt)) === (a = 1, c = false)
+
+    if VERSION >= v"1.1" 
+        @test @inferred((x -> deleteproperty(x, :b))(nt)) === (a = 1, c = false, d = :abc)
+        @test @inferred((x -> deleteproperties(x, (:b, :d)))(nt)) === (a = 1, c = false)
+    else
+        # Inference doesn't seem to handle this on Julia 1.0 (but can on 1.1)
+        @test (x -> deleteproperty(x, :b))(nt) === (a = 1, c = false, d = :abc)
+        @test (x -> deleteproperties(x, (:b, :d)))(nt) === (a = 1, c = false)
+    end
 
     c1 = @Compute($b)
     @test c1 isa TypedTables.GetProperty


### PR DESCRIPTION
Export the following functions

 * `getproperties` which lets you specify a tuple of symbols to get a subset of properties from a table or row.
 * `deleteproperty` which lets you specify a symbols to get a all properties except the specified one from a table or row.
 * `deleteproperties` which lets you specify a tuple of symbols to get a all properties except the specified ones from a table or row.

CC @EvertSchippers