### PR TITLE
add Plots.jl recipes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 docs/build
 docs/site
 docs/Manifest.toml
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,23 +1,24 @@
-authors = ["Andy Ferris <ferris.andy@gmail.com>"]
 name = "TypedTables"
 uuid = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
+authors = ["Andy Ferris <ferris.andy@gmail.com>"]
 version = "1.4.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 Dictionaries = "85a47980-9c8c-11e8-2b9f-f7ca1fa99fb4"
 Indexing = "313cdc1a-70c2-5d6a-ae34-0150d3930a38"
+RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 SplitApplyCombine = "03a91e81-4c3e-53e1-a0a4-9c0c8f19dd66"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
-julia = "1"
 Adapt = "1, 2, 3"
+Dictionaries = "0.3"
 Indexing = "1"
 SplitApplyCombine = "1"
 Tables = "1"
-Dictionaries = "0.3"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/TypedTables.jl
+++ b/src/TypedTables.jl
@@ -6,6 +6,7 @@ using SplitApplyCombine
 import Adapt
 using Dictionaries
 using Indexing
+using RecipesBase
 
 using Base: @propagate_inbounds, @pure, OneTo, Fix2
 import Tables.columns, Tables.rows
@@ -52,5 +53,6 @@ include("FlexTable.jl")
 include("DictTable.jl")
 include("columnops.jl")
 include("show.jl")
+include("plot.jl")
 
 end # module

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -1,0 +1,33 @@
+@recipe function f(tt::Table; indices = [1,2])
+    if length(indices) == 2
+        x_name, y_name = propertynames(tt)[indices]
+        xguide --> string(x_name)
+        yguide --> string(y_name)
+        return getproperty(tt, x_name), getproperty(tt, y_name)
+    elseif length(indices) == 3
+        x_name, y_name, z_name = propertynames(tt)[indices]
+        xguide --> string(x_name)
+        yguide --> string(y_name)
+        zguide --> string(z_name)
+        return getproperty(tt, x_name), getproperty(tt, y_name), getproperty(tt, z_name)
+    else
+        throw(ArgumentError("Keyword argument `indices` needs to be an integer array of length 2 or 3."))
+    end
+end
+
+@recipe function f(tt::Table, column_names)
+    if length(column_names) == 2
+        x_name, y_name = column_names
+        xguide --> string(x_name)
+        yguide --> string(y_name)
+        return getproperty(tt, x_name), getproperty(tt, y_name)
+    elseif length(column_names) == 3
+        x_name, y_name, z_name = column_names
+        xguide --> string(x_name)
+        yguide --> string(y_name)
+        zguide --> string(z_name)
+        return getproperty(tt, x_name), getproperty(tt, y_name), getproperty(tt, z_name)
+    else
+        throw(ArgumentError("The second argument `column_names` needs to be of length 2 or 3."))
+    end
+end


### PR DESCRIPTION
This adds two recipes to automatically set the labels.

```julia
using TypedTables, Plots
tt = Table(a=[1,2,3], b=[4,3,6], c=[0.2,2.0,5.4])
plot(tt)
```
gives takes first column as `x` and second column as `y`.
Then you can use either of
```julia
plot(tt; indices = [2,3])
plot(tt, (:a, :c))
```
to get other combinations.

Currently this only works for `Table`s, but with a common supertype this could potentially be extended to more `TypedTables`. 