### PR TITLE
Resolve warning re use of `kwargs.data`

### DIFF
--- a/src/DictTable.jl
+++ b/src/DictTable.jl
@@ -28,7 +28,7 @@ end
 
 
 function DictTable(ts...; kwargs...) 
-    cols = removenothings_dict(merge(_columns(ts...), kwargs.data))
+    cols = removenothings_dict(merge(_columns(ts...), values(kwargs)))
     inds = keys(first(cols))
     return DictTable{eltype(inds), _eltypes(cols), typeof(cols), typeof(inds)}(cols, inds)
 end


### PR DESCRIPTION
In Julia v1.8.0-rc4 creating a `DictTable` produces a warning of the form
```
┌ Warning: use values(kwargs) and keys(kwargs) instead of kwargs.data and kwargs.itr
│   caller = #DictTable#117 at DictTable.jl:31 [inlined]
└ @ Core ~/.julia/packages/TypedTables/zfbS2/src/DictTable.jl:31
```