### PR TITLE
`Base.getindex` over allocating: use generator for getindex

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 authors = ["Andy Ferris <ferris.andy@gmail.com>"]
 name = "TypedTables"
 uuid = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
-version = "1.4.1"
+version = "1.4.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Table.jl
+++ b/src/Table.jl
@@ -126,17 +126,12 @@ end
 
 @inline function Base.getindex(t::Table{T}, i::Int) where {T}
     @boundscheck checkbounds(t, i)
-    # AbstractArray{T} expects a subtype of T, and NamedTuples are invariant.
-    # For e.g. columns which are Union types we makes sure we emit a named tuple with Union
-    # elements. The convert should be a no-op in the case of strongly-typed columns.
-
-    # TODO find a way to make this faster than O(2^N) for N Union columns
-    convert(T, map(col -> @inbounds(getindex(col, i)), columns(t)))::T
+    return T(@inbounds(getindex(col, i)) for col in columns(t))
 end
 
 @inline function Base.getindex(t::Table{T}, i::Int...) where {T}
     @boundscheck checkbounds(t, i...)
-    convert(T, map(col -> @inbounds(getindex(col, i...)), columns(t)))::T
+    return T(@inbounds(getindex(col, i...) for col in columns(t)))
 end
 
 @inline function Base.setindex!(t::Table{T}, v::T, i::Int) where {T}


### PR DESCRIPTION
I came across this while developing my package [`LazyTables.jl`](https://github.com/m-wells/LazyTables.jl)

This should greatly improve performance of `TypedTables` (although for complex row by row operations `LazyTables` should still outperform).

As you can see for a simply indexing operation `TypedTables` makes 24 allocations when it only needs to make one.

```julia
(@v1.8) pkg> free TypedTables
   Resolving package versions...
    Updating `~/.julia/environments/v1.8/Project.toml`
  [9d95f2ec] ~ TypedTables v1.4.1 `~/.julia/dev/TypedTables` ⇒ v1.4.1
    Updating `~/.julia/environments/v1.8/Manifest.toml`
  [9d95f2ec] ~ TypedTables v1.4.1 `~/.julia/dev/TypedTables` ⇒ v1.4.1

julia> using TypedTables
[ Info: Precompiling TypedTables [9d95f2ec-7b3d-5a63-8d20-e2491e220bb9]
WARNING: method definition for broadcasted at /home/mark/.julia/packages/TypedTables/dycVq/src/DictTable.jl:301 declares type variable N but does not use it.
WARNING: method definition for broadcasted at /home/mark/.julia/packages/TypedTables/dycVq/src/DictTable.jl:305 declares type variable N but does not use it.
WARNING: method definition for broadcasted at /home/mark/.julia/packages/TypedTables/dycVq/src/DictTable.jl:309 declares type variable N but does not use it.
WARNING: method definition for broadcasted at /home/mark/.julia/packages/TypedTables/dycVq/src/DictTable.jl:313 declares type variable N but does not use it.
WARNING: method definition for broadcasted at /home/mark/.julia/packages/TypedTables/dycVq/src/DictTable.jl:317 declares type variable N but does not use it.

julia> table = Table(NamedTuple(Symbol(s) => rand(rand((Bool, Float32, Int, Float64)), 1000) for s in Char.(97:122)));

julia> table[3]; @time table[3];
  0.000011 seconds (24 allocations: 1.250 KiB)
```

```julia
(@v1.8) pkg> dev TypedTables
   Resolving package versions...
  No Changes to `~/.julia/environments/v1.8/Project.toml`
  No Changes to `~/.julia/environments/v1.8/Manifest.toml`

julia> using TypedTables

julia> table = Table(NamedTuple(Symbol(s) => rand(rand((Bool, Float32, Int, Float64)), 1000) for s in Char.(97:122)));

julia> table[3]; @time table[3];
  0.000004 seconds (1 allocation: 144 bytes)
```

