### PR TITLE
Bump compat for Adapt to 4, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
-Adapt = "1, 2, 3"
+Adapt = "1, 2, 3, 4"
 Dictionaries = "0.3"
 Indexing = "1"
 SplitApplyCombine = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TypedTables"
 uuid = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
 authors = ["Andy Ferris <ferris.andy@gmail.com>"]
-version = "1.4.3"
+version = "1.4.4"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
Adapt v4.0.0 features breaking changes in `Adapt.ndims`, `Adapt.eltype` and `Adapt.parent` 
(see https://github.com/JuliaGPU/Adapt.jl/releases/tag/v4.0.0)

`TypedTables` only seems to be using `Adapt.adapt`, `Adapt.adapt_structure` and `Adapt.adapt_storage`, so it should not be affected by the changes made in Adapt v4.0.0.
