### PR TITLE
Fix copy, simplify show

### DIFF
--- a/src/DictTable.jl
+++ b/src/DictTable.jl
@@ -215,6 +215,14 @@ function Base.filter!(pred, t::DictTable)
     return t
 end
 
+function Base.copy(t::DictTable)
+    inds = copy(keys(t))
+    cols = _similar(inds, eltype(t))
+    out = DictTable{keytype(t), eltype(t), typeof(cols), typeof(inds)}(cols, inds)
+    copyto!(out, t)
+    return out
+end
+
 # Column-based operations: Some operations on rows are faster when considering columns
 
 Base.map(::typeof(identity), t::DictTable) = copy(t)

--- a/src/show.jl
+++ b/src/show.jl
@@ -138,7 +138,7 @@ function showtable(io::IO, @nospecialize(t), keyname)
                 else
                     col = cols[col_inds[i-1]]
                     if isassigned(col, row_ind)
-                        push!(strings[i], compact_string(t[row_ind][col_inds[i-1]]))
+                        push!(strings[i], compact_string(col[row_ind]))
                     else
                         push!(strings[i], "#undef")
                     end


### PR DESCRIPTION
This fixes a problem with copying DictTable (since changes in Dictionaries.jl) as well as a problem with printing tables containing #undef values.